### PR TITLE
verified flag is also updated on edited invoice object

### DIFF
--- a/frontend/src/components/invoice/invoice-edit/EditInvoice.tsx
+++ b/frontend/src/components/invoice/invoice-edit/EditInvoice.tsx
@@ -194,7 +194,7 @@ const EditInvoice = () => {
               // it doesn't update on the edited object invoice. So the verified flag is overridden when you save
               // the edited object invoice. This if check fixes that
               if (initInvoice.verified !== invoice.verified) {
-                invoice.verified = initInvoice.verified
+                invoice.verified = initInvoice.verified;
               }
               if (type === 'create') {
                 dispatch(createInvoice(invoice, navigate) as any);

--- a/frontend/src/components/invoice/invoice-edit/EditInvoice.tsx
+++ b/frontend/src/components/invoice/invoice-edit/EditInvoice.tsx
@@ -190,6 +190,12 @@ const EditInvoice = () => {
           )}
           <EditInvoiceSaveButtons
             onClick={(type, navigate) => {
+              // When the InvoiceNotVerifiedAlert component updates the verified flag to true on initInvoice,
+              // it doesn't update on the edited object invoice. So the verified flag is overridden when you save
+              // the edited object invoice. This if check fixes that
+              if (initInvoice.verified !== invoice.verified) {
+                invoice.verified = initInvoice.verified
+              }
               if (type === 'create') {
                 dispatch(createInvoice(invoice, navigate) as any);
               } if (type === 'preview') {


### PR DESCRIPTION
issue https://github.com/itenium-be/confac/issues/221

This whole edit screen along with some other edit screens should probably be refactored when we decide on how we want to handle forms, like we discussed. It's not great that the invoice object is split into different objects and can be updated separately like in this case for the verified flag on both the initInvoice and invoice objects