### PR TITLE
fix NotesModalButton

### DIFF
--- a/frontend/src/components/controls/form-controls/button/NotesModalButton.tsx
+++ b/frontend/src/components/controls/form-controls/button/NotesModalButton.tsx
@@ -24,10 +24,6 @@ export const NotesModalButton = ({claim, value, onChange, title, variant, disabl
   const icon = !value ? 'far fa-comment' : 'far fa-comment-dots';
   const showConfirm = !disabled && (!claim || (claim && authService.getClaims().includes(claim)));
 
-  if(!text && value){
-    setText(value);
-  }
-
   return (
     <>
       <Button

--- a/frontend/src/components/controls/form-controls/button/NotesModalButton.tsx
+++ b/frontend/src/components/controls/form-controls/button/NotesModalButton.tsx
@@ -23,6 +23,11 @@ export const NotesModalButton = ({claim, value, onChange, title, variant, disabl
 
   const icon = !value ? 'far fa-comment' : 'far fa-comment-dots';
   const showConfirm = !disabled && (!claim || (claim && authService.getClaims().includes(claim)));
+
+  if(!text && value){
+    setText(value);
+  }
+
   return (
     <>
       <Button

--- a/frontend/src/components/invoice/invoice-edit/EditInvoice.tsx
+++ b/frontend/src/components/invoice/invoice-edit/EditInvoice.tsx
@@ -95,13 +95,13 @@ const EditInvoice = () => {
             </div>
             <div>
               <div className={`invoice-top-buttonbar ${storeInvoice?._id ? 'invoice-edit' : 'invoice-new'}`}>
-                <NotesModalButton
+                {invoice.note && <NotesModalButton
                   claim={invoice.isQuotation ? Claim.ManageQuotations : Claim.ManageInvoices}
                   value={invoice.note}
                   onChange={val => updateInvoice('note', val)}
                   title={t('projectMonth.note')}
                   variant="link"
-                />
+                />}
                 {initInvoice._id && <DownloadInvoiceButton invoice={initInvoice} />}
                 {storeInvoice?._id && !storeInvoice?.isQuotation && <InvoiceDownloadIcon invoice={invoice} fileType='xml' style={{color: '#0062cc', marginLeft: 20}} />}
               </div>


### PR DESCRIPTION
Fixes a bug with the NotesModalButton on the EditInvoice page. When a user saves a note and immediately refreshes the page, the notes modal does not show the saved note. 

This partially fixes https://github.com/itenium-be/confac/issues/275 